### PR TITLE
diffrentiate accesdenied error

### DIFF
--- a/micloud/micloudexception.py
+++ b/micloud/micloudexception.py
@@ -16,3 +16,15 @@ class MiCloudException(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
+
+class MiCloudAccessDenied(Exception):
+    """Exception raised for wrong credentials in the micloud library.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)


### PR DESCRIPTION
diffrentiate between socket errors and accesdenied errors in order to appropriatly hadel then upstream (in HomeAssistant).

Upstream in HomeAssistant:
When the Pi reboots the internet connection can still be down on first setup of the Xiaomi Miio integration, this causes a socket error in the micloud login request, in that case we want to raise PlatformNotReady and retry after a delay.
If however the credentials are wrong, we want to raise AccesDenied to trigger a reauthentication flow to specify new credentials.